### PR TITLE
Added MarkdownExtra support

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -3,14 +3,37 @@ namespace EdpMarkdown;
 
 class Module extends \Zend\View\Helper\AbstractHelper
 {
+    const MARKDOWN_NORMAL = 'normal';
+    const MARKDOWN_EXTRA = 'extra';
+    
+    protected $classWhitelist = array(
+        self::MARKDOWN_NORMAL => '\Michelf\Markdown',
+        self::MARKDOWN_EXTRA => '\Michelf\MarkdownExtra'
+    );
+    
+    protected static $defaultType = self::MARKDOWN_NORMAL;
+    
     public function getViewHelperConfig()
     {
         return array('services' => array('markdown' => $this));
     }
 
-    public function __invoke($string = null)
+    public function __invoke($string = null, $type = null)
     {
-        if (!class_exists('Michelf\Markdown')) require_once __DIR__ . '/vendor/php-markdown/Michelf/Markdown.inc.php';
-        return \Michelf\Markdown::defaultTransform($string);
+        if (null == $type) {
+            $type = self::$defaultType;
+        }
+        
+        $className = $this->classWhitelist[$type];
+        if (!class_exists($className)) {
+            $fileName = str_replace('\\', '/', $className) . '.inc.php';
+            require_once __DIR__ . '/vendor/php-markdown' . $fileName;
+        }
+        return $className::defaultTransform($string);
+    }
+    
+    public static function setDefaultType($type)
+    {
+        self::$defaultType = $type;
     }
 }

--- a/README.md
+++ b/README.md
@@ -17,14 +17,29 @@ To install EdpMarkdown, simply recursively clone this repository (`git clone
 With this module installed, using Markdown in your view scripts is easy:
 
 ```php
-<?= $this->markdown('Hello, **this** is _Markdown_!'); ?>
+<?php echo $this->markdown('Hello, **this** is _Markdown_!'); ?>
+```
+
+You may also use MarkdownExtra with this module:
+
+```php
+<?php echo $this->markdown('Hello, **this** is <strong>MarkdownExtra</strong>!', \EdpMarkdown\Module::MARKDOWN_EXTRA); ?>
+```
+
+or simpler:
+
+```php
+<?php echo $this->markdown('Hello, **this** is <strong>MarkdownExtra</strong>!', 'extra'); ?>
+```
+
+If you want all your calls to the markdown-helper to use MarkdownExtra, you can setup the default Markdown-type as follows:
+
+```php
+// For example in your onBootsrap-method:
+\EdpMarkdown\Module::setDefaultType(\EdpMarkdown\Module::MARKDOWN_EXTRA);
 ```
 
 **NOTE:** For security purposes, the output **SHOULD** be [sanitized](http://htmlpurifier.org/) if the Markdown is from an untrusted source. ([@padraic](https://github.com/padraic) says so!) See the [Markdown documentation on inline HTML](http://daringfireball.net/projects/markdown/syntax#html) to understand why this is necessary.
-
-## Configuration
-
-TODO: Create simple way to toggle to the 'extra' parser.
 
 ## License
 


### PR DESCRIPTION
Added functionality to choose MarkdownExtra for parsing. Adjusted the
readme.md

I am using markdown for my website. I used EdpMarkdown to parse my texts. However I needed MarkdownExtra-support. I was sad that EdpMarkdown didn't support it in the first place. In the readme.md MarkdownExtra-support is listed as a todo, so I thought I'd just add that support.
